### PR TITLE
feat: add_action api test and fix up readme

### DIFF
--- a/bin/si-api-test/README.md
+++ b/bin/si-api-test/README.md
@@ -5,22 +5,22 @@
 Run all tests (with auth api running locally):
 
 ```shell
-export SDF_API_URL="http://localhost:8080" 
-export AUTH_API_URL="http://localhost:9001" 
+export SDF_API_URL="http://localhost:8080"
+export AUTH_API_URL="http://localhost:9001"
 
 deno task run --workspace-id $WORKSPACE_ID \
               --userId $EMAIL \
               --password $PASSWORD \
-              --profile '{"Duration": "5", "Requests": 5}'
-              --tests create_and_use_variant,get_head_changeset 
-
+              --profile '{"maxDuration": "5", "rate": "1", "useJitter": false}'
+              --tests create_and_use_variant,get_head_changeset
 
 Usage: deno run main.ts [options]
 
 Options:
   --workspaceId, -w   Workspace ID (required)
-  --userId, -u        User ID (required)
-  --password, -p      User password (optional)
+  --userId, -u        User ID (optional, if token is provided)
+  --password, -p      User password (optional, if token is provided)
+  --token, -t         User token (optional, if userId and password are provided)
   --tests, -t         Test names to run (comma-separated, optional)
   --profile, -l       Test profile in JSON format (optional)
   --help              Show this help message

--- a/bin/si-api-test/sdf_api_client.ts
+++ b/bin/si-api-test/sdf_api_client.ts
@@ -68,6 +68,14 @@ export const ROUTES = {
     path: () => `/variant/create_variant`,
     method: "POST",
   },
+
+  // Action Management -----------------------------------------------------------
+  action_list: {
+    path: (vars: ROUTE_VARS) =>
+      `/action/list?visibility_change_set_pk=${vars.changeSetId}`,
+    method: "GET",
+  },
+
   // Add more groups below ------------------------------------------------------
 } satisfies Record<string, API_DESCRIPTION>;
 

--- a/bin/si-api-test/tests/add_action.ts
+++ b/bin/si-api-test/tests/add_action.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert";
+import { SdfApiClient } from "../sdf_api_client.ts";
+import { runWithTemporaryChangeset } from "../test_helpers.ts";
+
+export default async function add_action(sdfApiClient: SdfApiClient) {
+  return runWithTemporaryChangeset(sdfApiClient, add_action_inner);
+}
+
+export async function add_action_inner(
+  sdfApiClient: SdfApiClient,
+  changeSetId: string,
+) {
+  let data = await sdfApiClient.call({
+    route: "action_list",
+    routeVars: {
+      changeSetId,
+    },
+  });
+
+  const actionOriginalLength = data.length;
+
+  // Get all Schema Variants
+  const schemaVariants = await sdfApiClient.call({
+    route: "schema_variants",
+    routeVars: { changeSetId },
+  });
+
+  assert(
+    Array.isArray(schemaVariants),
+    "List schema variants should return an array",
+  );
+  const EC2InstanceVariantId = schemaVariants.find(
+    (sv) => sv.schemaName === "EC2 Instance",
+  )?.schemaVariantId;
+  assert(
+    EC2InstanceVariantId,
+    "Expected to find EC2 Instance schema and variant",
+  );
+
+  // Create the Component
+  const createComponentPayload = {
+    schemaVariantId: EC2InstanceVariantId,
+    x: "0",
+    y: "0",
+    visibility_change_set_pk: changeSetId,
+    workspaceId: sdfApiClient.workspaceId,
+  };
+  const createComponentResp = await sdfApiClient.call({
+    route: "create_component",
+    body: createComponentPayload,
+  });
+
+  const newComponentId = createComponentResp?.componentId;
+  assert(newComponentId, "Expected to get a component id after creation");
+  console.log(newComponentId);
+  console.log(changeSetId);
+
+  // Assert that an action has been queued for EC2 Instance component
+  data = await sdfApiClient.call({
+    route: "action_list",
+    routeVars: {
+      changeSetId,
+    },
+  });
+
+  // Check if any object in the array has the expected componentId
+  const hasComponentId = data.some(
+    (item) => item.componentId === newComponentId,
+  );
+
+  assert.strictEqual(
+    hasComponentId,
+    true,
+    "No action with the expected componentId found",
+  );
+  assert.strictEqual(
+    data.length,
+    actionOriginalLength + 1,
+    "Incorrect number of actions listed",
+  );
+}


### PR DESCRIPTION
Added action_list API Endpoint to client and created a test checking an action is added to the action_list when a component is created on a change set. 

Updated Readme for API testing tool. 

<div><img src="https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExOWRjMjAwMzR4ZDBrZ3B1NWppOXFoMzduM2F0eWVtYXBveGRzejJudiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9dg/KpJ47gKe6b7v7xQyWj/giphy.gif"/></div>